### PR TITLE
docs: typo in next env var name

### DIFF
--- a/quickstarts/fullstack/next.mdx
+++ b/quickstarts/fullstack/next.mdx
@@ -142,7 +142,7 @@ import { useEffect, useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 import { register, Hanko } from "@teamhanko/hanko-elements";
  
-const hankoApi = process.env.HANKO_API_URL;
+const hankoApi = process.env.NEXT_PUBLIC_HANKO_API_URL;
  
 export default function HankoAuth() {
   const router = useRouter();


### PR DESCRIPTION
typo in docs. 