### PR TITLE
Fixing typo in Add Google Login steps

### DIFF
--- a/guides/authentication-methods/oauth/google.mdx
+++ b/guides/authentication-methods/oauth/google.mdx
@@ -87,7 +87,7 @@ sidebarTitle: Google
       width={600}
     />
 
-- Click 'Credentials' in the right sidebar, then click 'Create credentials' and select 'OAuth client ID'
+- Click 'Credentials' in the left sidebar, then click 'Create credentials' and select 'OAuth client ID'
 
     <img
       className="border-[1px] border-black rounded-[10px]"


### PR DESCRIPTION
**Fixing typo**
![image](https://github.com/teamhanko/docs/assets/98174971/ac068d61-d053-4aeb-8987-53eb56bbda39)

Click ‘Credentials’ in the right sidebar, then click ‘Create credentials’ and select ‘OAuth client ID’

Changed this to:

Click ‘Credentials’ in the left sidebar, then click ‘Create credentials’ and select ‘OAuth client ID’