### PR TITLE
enhance: add docs for vite with react

### DIFF
--- a/community-support/troubleshoot.mdx
+++ b/community-support/troubleshoot.mdx
@@ -44,7 +44,7 @@ export const dynamic = "force-dynamic";
     <img src="/images/troubleshoot/404-error.png" style={{ borderRadius: "0.5rem" }} />
   </Frame>
 
-  Hanko Auth Component:
+  Hanko Auth Component
   <Frame>
     <img src="/images/troubleshoot/technical-error.png" style={{ borderRadius: "0.5rem" }} />
   </Frame>
@@ -52,17 +52,17 @@ export const dynamic = "force-dynamic";
    
    Here are some of the examples 
 
-    ```sh env
-    In Next.js
+    ```sh .env
+    Next.js
     NEXT_PUBLIC_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
 
-    In Nuxt
+    Nuxt
     NUXT_PUBLIC_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
     
-    In SvelteKit
+    SvelteKit
     PUBLIC_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
     
-    In React
+    React
     REACT_APP_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
   ```
   </Accordion>

--- a/quickstarts/frontend/react.mdx
+++ b/quickstarts/frontend/react.mdx
@@ -4,8 +4,6 @@ title: Integrate Hanko with React
 description: Learn how to quickly add authentication and user profile in your React app using Hanko.
 ---
 
-
-
 ## Install `@teamhanko/hanko-elements`
 
 Once you've initialized your React app, installing hanko-elements provides you with access to the prebuilt components: `hanko-auth` and `hanko-profile`.
@@ -22,15 +20,25 @@ pnpm add @teamhanko/hanko-elements
 ```bash yarn
 yarn add @teamhanko/hanko-elements
 ```
+
 </CodeGroup>
 
 ## Add the Hanko API URL
 
 Retrieve the API URL from the [Hanko console](https://cloud.hanko.io/) and place it in your .env file.
 
-```sh .env
-REACT_APP_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
-```
+<Tabs>
+  <Tab title="Create React App">
+    ```sh .env
+    REACT_APP_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
+    ```
+  </Tab>
+  <Tab title="React with Vite">
+    ```sh .env
+    VITE_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
+    ```
+  </Tab>
+</Tabs>
 
 <Note>
   If you are self-hosting you need to provide the URL of your running Hanko
@@ -41,90 +49,175 @@ REACT_APP_HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
 
 The `<hanko-auth>` web component adds a login interface to your app. Begin by importing the `register` function from `@teamhanko/hanko-elements` into your React component. Call it with the Hanko API URL as an argument to register `<hanko-auth>` with the browser's [CustomElementRegistry](https://developer.mozilla.org/de/docs/Web/API/CustomElementRegistry). Once done, include it in your JSX.
 
-```jsx components/HankoAuth.tsx
-import { useEffect } from "react";
-import { register } from "@teamhanko/hanko-elements";
+<Tabs>
+  <Tab title="Create React App">
+    ```jsx components/HankoAuth.tsx
+    import { useEffect } from "react";
+    import { register } from "@teamhanko/hanko-elements";
 
-const hankoApi = process.env.REACT_APP_HANKO_API_URL;
+    const hankoApi = process.env.REACT_APP_HANKO_API_URL;
 
-export default function HankoAuth() {
-  useEffect(() => {
-    register(hankoApi).catch((error) => {
-      // handle error
-    });
-  }, []);
+    export default function HankoAuth() {
+      useEffect(() => {
+        register(hankoApi).catch((error) => {
+          // handle error
+        });
+      }, []);
 
-  return <hanko-auth />;
-}
-```
+      return <hanko-auth />;
+    }
+    ```
+  </Tab>
+  <Tab title="React with Vite">
+    ```jsx components/HankoAuth.tsx
+    import { useEffect } from "react";
+    import { register } from "@teamhanko/hanko-elements";
+
+    const hankoApi = import.meta.env.VITE_HANKO_API_URL;
+
+    export default function HankoAuth() {
+      useEffect(() => {
+        register(hankoApi).catch((error) => {
+          // handle error
+        });
+      }, []);
+
+      return <hanko-auth />;
+    }
+    ```
+  </Tab>
+</Tabs>
+
+
 
 ## Define event callbacks
 
 The Hanko client from `@teamhanko/hanko-elements` lets you "listen" for specific [events](https://github.com/teamhanko/hanko/blob/main/frontend/elements/README.md#events). It simplifies the process of subscribing to events, such as user logins.
 
-```jsx components/HankoAuth.tsx
-import { useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { register, Hanko } from "@teamhanko/hanko-elements";
+<Tabs>
+  <Tab title="Create React App">
+    ```jsx components/HankoAuth.tsx
+    import { useEffect, useCallback } from "react";
+    import { useNavigate } from "react-router-dom";
+    import { register, Hanko } from "@teamhanko/hanko-elements";
 
-const hankoApi = process.env.REACT_APP_HANKO_API_URL;
+    const hankoApi = process.env.REACT_APP_HANKO_API_URL;
 
-export default function HankoAuth() {
-  const navigate = useNavigate();
-  const hanko = useMemo(() => new Hanko(hankoApi), []);
+    export default function HankoAuth() {
+      const navigate = useNavigate();
+      const hanko = useMemo(() => new Hanko(hankoApi), []);
 
-  const redirectAfterLogin = useCallback(() => {
-    navigate("/dashboard");
-  }, [navigate]);
+      const redirectAfterLogin = useCallback(() => {
+        navigate("/dashboard");
+      }, [navigate]);
 
-  useEffect(
-    () =>
-      hanko.onAuthFlowCompleted(() => {
-        redirectAfterLogin();
-      }),
-    [hanko, redirectAfterLogin]
-  );
+      useEffect(
+        () =>
+          hanko.onAuthFlowCompleted(() => {
+            redirectAfterLogin();
+          }),
+        [hanko, redirectAfterLogin]
+      );
 
-  useEffect(() => {
-    register(hankoApi).catch((error) => {
-      // handle error
-    });
-  }, []);
+      useEffect(() => {
+        register(hankoApi).catch((error) => {
+          // handle error
+        });
+      }, []);
 
-  return <hanko-auth />;
-}
-```
+      return <hanko-auth />;
+    }
+    ```
+  </Tab>
+  <Tab title="React with Vite">
+  ```jsx components/HankoAuth.tsx
+  import { useEffect, useCallback } from "react";
+  import { useNavigate } from "react-router-dom";
+  import { register, Hanko } from "@teamhanko/hanko-elements";
+
+  const hankoApi = import.meta.env.VITE_HANKO_API_URL;
+
+  export default function HankoAuth() {
+    const navigate = useNavigate();
+    const hanko = useMemo(() => new Hanko(hankoApi), []);
+
+    const redirectAfterLogin = useCallback(() => {
+      navigate("/dashboard");
+    }, [navigate]);
+
+    useEffect(
+      () =>
+        hanko.onAuthFlowCompleted(() => {
+          redirectAfterLogin();
+        }),
+      [hanko, redirectAfterLogin]
+    );
+
+    useEffect(() => {
+      register(hankoApi).catch((error) => {
+        // handle error
+      });
+    }, []);
+
+    return <hanko-auth />;
+  }
+  ```
+  </Tab>
+</Tabs>
+
+
+
 
 By now, your sign-up and sign-in features should be working. You should see an interface similar to this 👇
+
 <br />
-<img
-  src="/images/fullstack-guide/next-one.png"
-  alt="sign up"
-  width={500}
-/>
+<img src="/images/fullstack-guide/next-one.png" alt="sign up" width={500} />
 
 ## Add `<hanko-profile>` component
 
 The `<hanko-profile>` component provides an interface, where users can manage their email addresses and passkeys.
 
-```jsx components/HankoProfile.tsx
-import { useEffect } from "react";
-import { register } from "@teamhanko/hanko-elements";
+<Tabs>
+  <Tab title="Create React App">
+    ```jsx components/HankoProfile.tsx
+    import { useEffect } from "react";
+    import { register } from "@teamhanko/hanko-elements";
 
-const hankoApi = process.env.REACT_APP_HANKO_API_URL;
+    const hankoApi = process.env.REACT_APP_HANKO_API_URL;
 
-export default function HankoProfile() {
-  useEffect(() => {
-    register(hankoApi).catch((error) => {
-      // handle error
-    });
-  }, []);
+    export default function HankoProfile() {
+      useEffect(() => {
+        register(hankoApi).catch((error) => {
+          // handle error
+        });
+      }, []);
 
-  return <hanko-profile />;
-}
-```
+      return <hanko-profile />;
+    }
+    ```
+  </Tab>
+  <Tab title="React with Vite">
+    ```jsx components/HankoProfile.tsx
+    import { useEffect } from "react";
+    import { register } from "@teamhanko/hanko-elements";
+
+    const hankoApi = import.meta.env.VITE_HANKO_API_URL;
+
+    export default function HankoProfile() {
+      useEffect(() => {
+        register(hankoApi).catch((error) => {
+          // handle error
+        });
+      }, []);
+
+      return <hanko-profile />;
+    }
+    ```
+  </Tab>
+</Tabs>
 
 It should look like this 👇
+
 <br />
 <img
   src="/images/fullstack-guide/next-two.png"
@@ -136,37 +229,76 @@ It should look like this 👇
 
 You can use `@teamhanko/hanko-elements` to easily manage user logouts. Below, we make a logout button component that you can use anywhere.
 
-```jsx components/LogoutButton.tsx
-import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { Hanko } from "@teamhanko/hanko-elements";
+<Tabs>
+  <Tab title="Create React App">
+    ```jsx components/LogoutButton.tsx
+    import React, { useState, useEffect } from "react";
+    import { useNavigate } from "react-router-dom";
+    import { Hanko } from "@teamhanko/hanko-elements";
 
-const hankoApi = process.env.REACT_APP_HANKO_API_URL;
+    const hankoApi = process.env.REACT_APP_HANKO_API_URL;
 
-function LogoutBtn() {
-  const navigate = useNavigate();
-  const [hanko, setHanko] = useState<Hanko>();
+    function LogoutBtn() {
+      const navigate = useNavigate();
+      const [hanko, setHanko] = useState<Hanko>();
 
-  useEffect(() => {
-    import("@teamhanko/hanko-elements").then(({ Hanko }) =>
-      setHanko(new Hanko(hankoApi ?? ""))
-    );
-  }, []);
+      useEffect(() => {
+        import("@teamhanko/hanko-elements").then(({ Hanko }) =>
+          setHanko(new Hanko(hankoApi ?? ""))
+        );
+      }, []);
 
-  const logout = async () => {
-    try {
-      await hanko?.user.logout();
-      navigate("/login");
-    } catch (error) {
-      console.error("Error during logout:", error);
+      const logout = async () => {
+        try {
+          await hanko?.user.logout();
+          navigate("/login");
+        } catch (error) {
+          console.error("Error during logout:", error);
+        }
+      };
+
+      return <button onClick={logout}>Logout</button>;
     }
-  };
 
-  return <button onClick={logout}>Logout</button>;
-}
+    export default LogoutBtn;
+    ```
+  </Tab>
+  <Tab title="React with Vite">
+    ```jsx components/LogoutButton.tsx
+    import React, { useState, useEffect } from "react";
+    import { useNavigate } from "react-router-dom";
+    import { Hanko } from "@teamhanko/hanko-elements";
 
-export default LogoutBtn;
-```
+    const hankoApi = import.meta.env.VITE_HANKO_API_URL;
+
+    function LogoutBtn() {
+      const navigate = useNavigate();
+      const [hanko, setHanko] = useState<Hanko>();
+
+      useEffect(() => {
+        import("@teamhanko/hanko-elements").then(({ Hanko }) =>
+          setHanko(new Hanko(hankoApi ?? ""))
+        );
+      }, []);
+
+      const logout = async () => {
+        try {
+          await hanko?.user.logout();
+          navigate("/login");
+        } catch (error) {
+          console.error("Error during logout:", error);
+        }
+      };
+
+      return <button onClick={logout}>Logout</button>;
+    }
+
+    export default LogoutBtn;
+    ```
+  </Tab>
+</Tabs>
+
+
 
 ## Customize component styles
 


### PR DESCRIPTION
Lot of users initialize react project with vite instead of just create-react-app. The way to use env variables that are exposed to broswers is different in vite, so added those in code. Now React guide showcases both create-react-app and react with vite. 