### PR TITLE
Remove redundant/repeated sentence from note

### DIFF
--- a/quickstarts/frontend/javascript.mdx
+++ b/quickstarts/frontend/javascript.mdx
@@ -13,7 +13,7 @@ HANKO_API_URL=https://f4****-4802-49ad-8e0b-3d3****ab32.hanko.io
 ```
 
 <Note>
-  We recommend saving these keys in environment variables through .env file or any other equivalent. Also, if you are self-hosting you need to provide the URL of your running Hanko
+  If you are self-hosting, you need to provide the URL of your running Hanko
   backend.
 </Note>
 


### PR DESCRIPTION
The instructions tell the user to save the hanko url to a .env file, but the note says it also recommends doing the same thing. 