### PR TITLE
include an import statement for ssl

### DIFF
--- a/quickstarts/backend/python.mdx
+++ b/quickstarts/backend/python.mdx
@@ -27,6 +27,7 @@ This is an example of using a custom middleware in a [FastAPI](https://fastapi.t
 ```python 
 from typing import Any
 import os
+import ssl
 import jwt
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse


### PR DESCRIPTION
The documentation uses the python  ssl library without explicitly importing it, That will not work.