### PR TITLE
chore(api-spec): update session endpoint specs

### DIFF
--- a/openapi-public.yaml
+++ b/openapi-public.yaml
@@ -749,6 +749,10 @@ paths:
       responses:
         200:
           $ref: "#/components/responses/ValidateSessionResponse"
+        400:
+          $ref: "#/components/responses/BadRequest"
+        500:
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags:
         - Session Management
@@ -770,6 +774,8 @@ paths:
           $ref: "#/components/responses/ValidateSessionResponse"
         400:
           $ref: "#/components/responses/BadRequest"
+        500:
+          $ref: '#/components/responses/InternalServerError'
   /thirdparty/auth:
     get:
       summary: 'Initialize third party login'
@@ -1207,10 +1213,14 @@ components:
                 description: Date-time indicating the expiration of the session
                 type: string
                 format: date-time
+                deprecated: true
               user_id:
                 description: The ID of the user the session is associated with
                 type: string
                 format: uuid4
+                deprecated: true
+              claims:
+                $ref: '#/components/schemas/JWTClaims'
             required:
               - isValid
     BadRequest:
@@ -1666,6 +1676,40 @@ components:
           description: "The ID of the newly created email address"
           allOf:
             - $ref: '#/components/schemas/UUID4'
+    JWTClaims:
+      type: object
+      description: "The claims extracted from a JWT."
+      properties:
+        subject:
+          description: "The unique identifier of the token's subject."
+          allOf:
+            - $ref: '#/components/schemas/UUID4'
+        issued_at:
+          description: "The timestamp indicating when the token was issued."
+          type: string
+          format: date-time
+        expiration:
+          description: "The timestamp indicating when the token will expire."
+          type: string
+          format: date-time
+        audience:
+          description: "The intended audience of the token."
+          type: string
+        issuer:
+          description: "The entity that issued the token."
+          type: string
+        email:
+          description: "The email address associated with the token's subject, if available."
+          type: string
+          format: email
+        session_id:
+          description: "The unique identifier for the session associated with this token."
+          allOf:
+            - $ref: '#/components/schemas/UUID4'
+      required:
+        - subject
+        - expiration
+        - session_id
     User:
       type: object
       properties:

--- a/openapi-public.yaml
+++ b/openapi-public.yaml
@@ -1210,12 +1210,12 @@ components:
                 description: Indicates whether the session is valid or not
                 type: boolean
               expiration_time:
-                description: Date-time indicating the expiration of the session
+                description: Date-time indicating the expiration of the session. Deprecated, please use `claims.expiration` instead.
                 type: string
                 format: date-time
                 deprecated: true
               user_id:
-                description: The ID of the user the session is associated with
+                description: The ID of the user the session is associated with. Deprecated, please use `claims.subject` instead.
                 type: string
                 format: uuid4
                 deprecated: true
@@ -1694,14 +1694,26 @@ components:
           format: date-time
         audience:
           description: "The intended audience of the token."
-          type: string
+          type: array
+          items:
+            type: string
         issuer:
           description: "The entity that issued the token."
           type: string
         email:
-          description: "The email address associated with the token's subject, if available."
-          type: string
-          format: email
+          description: "Data about the email address associated with the token's subject, if available."
+          type: object
+          properties:
+            address:
+              description: "The actual email address."
+              type: string
+              format: email
+            is_primary:
+              description: "Indicates whether the email address is the primary address."
+              type: boolean
+            is_verified:
+              description: "Indicates whether the email address is verified."
+              type: boolean
         session_id:
           description: "The unique identifier for the session associated with this token."
           allOf:


### PR DESCRIPTION
### Description

This PR updates the OpenAPI specification for the session endpoints to align the response definitions to the API changes made in https://github.com/teamhanko/hanko/pull/2003 .

### Changes Made
1. **Endpoint Response Updates**:
   - Added `500` responses (`InternalServerError`) to the `GET /sessions/validate` and `POST /sessions/validate` endpoints for better documentation of potential server errors.
   - Enhanced the `400` responses (`BadRequest`) for these endpoints.

2. **Schema Enhancements**:
   - Introduced a new schema, `JWTClaims`, to describe the claims extracted from JWTs.
   - Includes fields are: `subject`, `issued_at`, `expiration`, `audience`, `issuer`, `email`, and `session_id`.
   - Deprecated the following fields in the `ValidateSessionResponse` schema:
     - `expires_at`
     - `user_id`

### Notes
- Consumers of the API are encouraged to transition to the new `JWTClaims` schema as the deprecated fields will be removed in a future release.