### PR TITLE
Added scrollbars to Mintlify Tabs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,15 @@
     "light": "#6575FF",
     "dark": "#0D001D"
   },
+  "head": [
+    {
+      "tag": "link",
+      "attrs": {
+        "rel": "stylesheet",
+        "href": "/custom.css"
+      }
+    }
+  ],
   "favicon": "/favicon.png",
   "navigation": {
     "tabs": [

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,0 +1,21 @@
+/* Custom css to add scrollbars to tabs */
+.tabs ul{
+    overflow-x: visible;
+    padding-bottom: 3px;
+}
+.tabs ul::-webkit-scrollbar{
+    height: 10px;
+    border: 1px solid rgba(139, 136, 136, 0.041);
+}
+.tabs ul::-webkit-scrollbar-track {
+    border-radius: 0;
+    background: #1212121e;
+} 
+.tabs ul::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: rgb(101,116,255);
+}
+.tabs ul::-webkit-scrollbar-track:hover ,  
+.tabs ul::-webkit-scrollbar-thumb:hover{
+    cursor: pointer;
+}


### PR DESCRIPTION
Added some custom css to show a scrollbar on the Mintlify Tabs.
This does not work in firefox.

Due to the switch from mint.json to docs.json the "head" property is not recognized by the schema used.
Although the "head" property is recognized by Mintlify allowing custom CSS to work.