### PR TITLE
feat: add a guide to build a custom login page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -136,7 +136,8 @@
               {
                 "group": "FlowAPI",
                 "pages": [
-                  "guides/flow-api/understanding-the-flow-api"
+                  "guides/flow-api/understanding-the-flow-api",
+                  "guides/flow-api/build-a-custom-login-page"
                 ]
               },
               "guides/sessions/session-management",

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -1,0 +1,542 @@
+---
+title: Build a Custom Login Page with the FlowAPI
+description: A step-by-step guide to create a custom frontend for the Hanko FlowAPI login page using the hanko-frontend-sdk.
+---
+
+# Introductiion
+
+This guide walks you through building a custom login page for the Hanko FlowAPI using the `hanko-frontend-sdk`. The
+resulting page handles email and passcode login, supports passkey autofill, and includes session management (redirect
+after login and logout functionality). The FlowAPI is part of Hanko, a user authentication platform, and we'll use a
+Hanko Cloud project configured for simplicity.
+
+By the end, you'll have a working login page that:
+
+- Initializes the login flow via the `/login` endpoint.
+- Dynamically renders UI for the states: `error`, `login_init`, `login_method_chooser`, `onboarding_create_passkey`,
+  and `passcode_confirmation`.
+- Handles user inputs, errors, and session events.
+- Runs locally at `http://localhost:3000` and authenticates a test user.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- **Node.js** installed for running a local server and installing dependencies.
+- A modern browser (e.g., Chrome, Firefox) for testing passkey autofill.
+- A Hanko Cloud project set up with a test user (see Step 1).
+- Basic knowledge of JavaScript, HTML, and CSS.
+
+## Step 1: Set Up the Development Environment
+
+<Steps>
+
+<Step title="Create and Configure a Hanko Cloud Project">
+- Go to [cloud.hanko.io](https://cloud.hanko.io) and log in.
+- In the sidebar, select **All Projects**.
+- Click **Create Project** to open the setup wizard.
+- Choose **Hanko** ("Authentication and user management") as the project type and click **Create Project**.
+- Enter a project name (e.g., "Custom Login Page").
+- Set the App URL to `http://localhost:3000` (where the login page will run locally).
+- Click **Create Project** to complete the wizard.
+</Step>
+
+<Step title="Configure the Project">
+- In the sidebar, go to **Settings > Authentication**.
+    - Uncheck **Passwords**, to turn off password authentication.
+    - Click **Save**.
+- Go to **Settings > 2FA**.
+    - Uncheck the entire **2FA** section.
+    - Click **Save**.
+- Under **Device trust** (further down on the same page):
+    - Select **Never** as the "Device trust policy" from the dropdown.
+    - Click **Save**.
+</Step>
+
+<Step title="Create a Test User">
+- In the sidebar, select **Users**.
+- Click **Create User** to open the user creation wizard.
+- Enter your real email address (in order to receive passcodes).
+- Click **Create new User** to finish.
+</Step>
+
+
+<Step title="Obtain your API URL">
+1. In the sidebar, select **Dashboard**.
+2. Find your project's API URL (e.g., `https://<project-id>.hanko.io`).
+</Step>
+
+<Step title="Set Up the Project Structure">
+Create a project folder (e.g., `hanko-login-page`) and set up the following files:
+```
+hanko-login-page/
+├ index.html
+├ script.js
+├ style.css
+├ success.html
+├ package.json
+└ .babelrc
+```
+</Step>
+
+<Step title="Create 'package.json'">
+```json
+{
+  "name": "hanko-login-page",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "parcel index.html --port 3000",
+    "build": "parcel build index.html success.html"
+  },
+  "dependencies": {
+    "@teamhanko/hanko-frontend-sdk": "^2.0.0",
+    "parcel": "^2.14.0"
+  },
+  "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.26.0",
+    "@parcel/optimizer-terser": "^2.14.4"
+  }
+}
+```
+</Step>
+
+<Step title="Create '.babelrc'">
+```json
+{
+  "plugins": ["@babel/plugin-transform-runtime"]
+}
+```
+</Step>
+
+<Step title="Install Dependencies">
+Run in the project folder:
+
+```bash
+npm install
+```
+</Step>
+
+<Step title="Create 'index.html' (the login page)">
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hanko Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="script.js"></script>
+</body>
+</html>
+```
+</Step>
+
+<Step title="Create 'success.html' (shown after login)">
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login Success</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <h1>Login Successful</h1>
+    <p>Welcome! You are now logged in.</p>
+    <button id="logout">Log Out</button>
+  </div>
+  <script type="module" src="script.js"></script>
+</body>
+</html>
+```
+</Step>
+
+<Step title="Create 'style.css'">
+
+```css
+body {
+  font-family: Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background-color: #f4f4f4;
+}
+
+#app {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+}
+
+h1 {
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+.form-group {
+  margin-bottom: 15px;
+  text-align: left;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+input {
+  width: -webkit-fill-available;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin: 5px;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+.error {
+  color: red;
+  font-size: 14px;
+  margin-top: 5px;
+}
+```
+
+</Step>
+
+<Step title="Start the Local Server">
+Run the following to start the server at http://localhost:3000:
+
+```bash
+npm start
+```
+
+Open `http://localhost:3000` in your browser to verify the page loads (it will be empty until we add JavaScript).
+</Step>
+
+</Steps>
+
+## Step 2: Initialize the Login Flow
+
+In `script.js`, initialize the Hanko instance and start the login flow. If the user is on `success.html`, set up logout
+functionality instead.
+
+```js
+import { Hanko } from "@teamhanko/hanko-frontend-sdk";
+
+// Replace with your Hanko Cloud project's API endpoint
+const API_URL = "https://<your-project-id>.hanko.io";
+
+// Initialize Hanko instance
+const hanko = new Hanko(API_URL);
+
+// Check if we're on the success page
+const isSuccessPage = window.location.pathname.includes("success.html");
+
+if (isSuccessPage) {
+  // Handle logout on success page
+  const logoutButton = document.getElementById("logout");
+  if (logoutButton) {
+    logoutButton.addEventListener("click", async () => {
+      try {
+        await hanko.logout();
+      } catch (error) {
+        console.error("Logout failed:", error);
+        alert("Failed to log out. Please try again.");
+      }
+    });
+  }
+  // Redirect to login page on logout
+  hanko.onUserLoggedOut(() => {
+    window.location.href = "/index.html";
+  });
+} else {
+  // Listen for state changes
+  hanko.onAfterStateChange(({ state }) => {
+    handleState(state); // To be implemented in the next step of this guide
+  });
+
+  // Listen for successful login
+  hanko.onSessionCreated(() => {
+    window.location.href = "/success.html";
+  });
+
+  // Initialize login flow on index.html
+  await hanko.createState("login");
+}
+```
+<Tip>
+Replace `https://<your-project-id>.hanko.io` with your project's API endpoint from the Hanko Cloud dashboard.
+</Tip>
+
+## Step 3: Handle Flow States and Render UI
+
+Implement handler functions to process each state and render the appropriate UI. The `hanko.onAfterStateChange` event is
+used to update the UI after state transitions. We'll also create a `generateInput` function to dynamically generate input
+elements with validation attributes (e.g., minlength, maxlength, required) based on the FlowAPI's input metadata.
+
+Add the following code to the `script.js` file:
+
+```js
+function generateInput(input, options = {}) {
+  const { name, type, min_length, max_length, required, error } = input;
+  const { autocomplete } = options;
+
+  // Build attributes
+  const attributes = [
+    `type="${type}"`,
+    `id="${name}"`,
+    `name="${name}"`,
+    required ? "required" : "",
+    min_length ? `minlength="${min_length}"` : "",
+    max_length ? `maxlength="${max_length}"` : "",
+    autocomplete ? `autocomplete="${autocomplete}"` : ""
+  ].join(" ");
+
+  // Generate HTML for the input group
+  return `
+    <div class="form-group">
+      <label for="${name}">${name.charAt(0).toUpperCase() + name.slice(1)}</label>
+      <input ${attributes}>${error ? `<p class="error">${error.message}</p>` : ""}
+    </div>`;
+}
+
+function handleState(state) {
+  const app = document.getElementById("app");
+  app.innerHTML = ""; // Clear previous content
+
+  switch (state.name) {
+    case "login_init":
+      renderLoginInit(state);
+      state.passkeyAutofillActivation(); // Enable passkey autofill
+      break;
+    case "login_method_chooser":
+      renderLoginMethodChooser(state);
+      break;
+    case "onboarding_create_passkey":
+      renderOnboardingCreatePasskey(state);
+      break;
+    case "passcode_confirmation":
+      renderPasscodeConfirmation(state);
+      break;
+    case "error":
+      renderError(state.error || { message: "An unexpected error occurred." });
+      break;
+  }
+}
+
+function renderLoginInit(state) {
+  const app = document.getElementById("app");
+  const action = state.actions.continue_with_login_identifier;
+  const emailInput = action.inputs.email || action.inputs.identifier;
+  const inputHtml = generateInput(emailInput, { autocomplete: "username webauthn" });
+
+  app.innerHTML = `
+    <h1>Log In</h1>
+    <form id="login-form">
+      ${inputHtml}
+      <button type="submit">Continue</button>
+    </form>`;
+
+  const form = document.getElementById("login-form");
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const email = form.querySelector(`#${emailInput.name}`).value;
+    await action.run({[emailInput.name]: email });
+  });
+}
+
+function renderLoginMethodChooser(state) {
+  const app = document.getElementById("app");
+
+  app.innerHTML = `
+    <h1>Choose Login Method</h1>
+    <div id="methods"></div>`;
+
+  const methods = document.getElementById("methods");
+  const actions = state.actions;
+
+  if (actions.continue_to_password_login.enabled) {
+    methods.innerHTML += `<button data-action="continue_to_password_login">Use Password</button>`;
+  }
+
+  if (actions.continue_to_passcode_confirmation.enabled) {
+    methods.innerHTML += `<button data-action="continue_to_passcode_confirmation">Use Passcode</button>`;
+  }
+
+  if (actions.back.enabled) {
+    methods.innerHTML += `<button data-action="back">Back</button>`;
+  }
+
+  methods.querySelectorAll("button").forEach((button) => {
+    button.addEventListener("click", async (e) => {
+      e.preventDefault();
+      const actionName = button.dataset.action;
+      await actions[actionName].run();
+    });
+  });
+ }
+
+function renderOnboardingCreatePasskey(state) {
+  const app = document.getElementById("app");
+
+  app.innerHTML = `
+    <h1>Create a Passkey</h1>
+    <p>Add a passkey for faster login (optional).</p>
+    <div id="actions"></div>`;
+
+  const actionsDiv = document.getElementById("actions");
+  const actions = state.actions;
+
+  if (actions.webauthn_generate_creation_options.enabled) {
+    actionsDiv.innerHTML += `<button data-action="webauthn_generate_creation_options">Create Passkey</button>`;
+  }
+  if (actions.skip.enabled) {
+    actionsDiv.innerHTML += `<button data-action="skip">Skip</button>`;
+  }
+  if (actions.back.enabled) {
+    actionsDiv.innerHTML += `<button data-action="back">Back</button>`;
+  }
+
+  actionsDiv.querySelectorAll("button").forEach(button => {
+    button.addEventListener("click", async () => {
+      const actionName = button.dataset.action;
+      await actions[actionName].run();
+    });
+  });
+}
+
+function renderPasscodeConfirmation(state) {
+  const app = document.getElementById("app");
+  const verifyAction = state.actions.verify_passcode;
+  const codeInput = verifyAction.inputs.code;
+  const inputHtml = generateInput(codeInput);
+
+  app.innerHTML = `
+    <h1>Enter Passcode</h1>
+    <p>Check your email for the passcode.</p>
+    <form id="passcode-form">
+      ${inputHtml}
+      <button type="submit">Verify</button>
+    </form>
+    <div id="actions"></div>`;
+
+    const form = document.getElementById("passcode-form");
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const code = form.querySelector(`#${codeInput.name}`).value;
+      await verifyAction.run({ code });
+    });
+
+    const actionsDiv = document.getElementById("actions");
+
+    if (state.actions.resend_passcode.enabled) {
+      actionsDiv.innerHTML += `<button data-action="resend_passcode">Resend Passcode</button>`;
+    }
+    if (state.actions.back ? .enabled) {
+      actionsDiv.innerHTML += `<button data-action="back">Back</button>`;
+    }
+
+    actionsDiv.querySelectorAll("button").forEach(button => {
+      button.addEventListener("click", async () => {
+        const actionName = button.dataset.action;
+        await state.actions[actionName].run();
+    });
+  });
+}
+
+function renderError(error) {
+  const app = document.getElementById("app");
+
+  app.innerHTML = `
+    <h1>Error</h1>
+    <p class="error">${error.message}</p>
+    <button id="retry">Try Again</button>`;
+
+  document.getElementById("retry").addEventListener("click", () => {
+    initializeLoginFlow();
+  });
+}
+```
+<Note>
+- The action execution logic is embedded in each state's form or button handlers.
+- The `hanko.onAfterStateChange` event ensures the UI updates after each action, and `hanko.onSessionCreated` redirects
+  to `success.html` on successful login.
+- On `success.html`, the logout button calls `hanko.logout()`, and `hanko.onUserLoggedOut` redirects back to the
+  `index.html`.
+- Validation Errors: Each state renderer checks for `state.actions.<action>.inputs.<input>.error` and displays the
+  message (e.g., invalid passcode).
+- Technical Errors: The error state handler displays `state.error.message`.
+</Note>
+
+## Step 4: Run and Test the Login Page
+
+<Steps>
+<Step title="Run the Application">
+- Ensure the Hanko Cloud project is configured as described (App URL: `http://localhost:3000`, no passwords, no 2FA,
+  device trust "Never").
+- Update `API_URL` in `script.js` with your Hanko Cloud project's API endpoint.
+- Rebuild the App:
+  ```bash
+  npm run build
+  ```
+- Run the local server:
+  ```bash
+  npm start
+  ```
+- Open `http://localhost:3000` in your browser.
+</Step>
+
+<Step title="Test the Login Flow">
+- Enter the test user's email.
+- Check your email for the passcode, enter the code, and click submit.
+- If prompted, register a passkey.
+- On success, you'll be redirected to `success.html`.
+- Click Log Out to return to the login page.
+</Step>
+
+<Step title="Troubleshooting">
+- CORS Errors: Ensure the App URL in the Hanko Cloud dashboard matches `http://localhost:3000`.
+- Invalid API URL: Verify the `API_URL` in `script.js`.
+- No Passcode Received: Confirm the test user's email is correct and check your spam folder.
+- Passkey Autofill Not Working: Use a passkey-compatible browser (e.g., Chrome) and ensure the input has
+  `autocomplete="username webauthn"`.
+</Step>
+
+</Steps>
+
+## Conclusion
+
+You've built a working login page that:
+- Uses the FlowAPI and hanko-frontend-sdk to handle email/passcode login.
+- Supports passkey autofill in the `login_init` state.
+- Manages sessions with redirect after login and logout functionality.
+- Handles errors gracefully across all specified states.
+
+<Tip>
+Explore next steps like enhancing the UI with advanced CSS or a framework like Bootstrap, adding support for additional
+states or actions (e.g., password login), or integrating the login page into a larger application.
+</Tip>
+

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -55,7 +55,7 @@ Before starting, ensure you have:
 
 <Step title="Create a Test User">
 - In the sidebar, select **Users**.
-- Click **Create User** to open the user creation wizard.
+- Click **Create new** to open the user creation wizard.
 - Enter your real email address (in order to receive passcodes).
 - Click **Create new User** to finish.
 </Step>

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -3,7 +3,7 @@ title: Build a Custom Login Page with the FlowAPI
 description: A step-by-step guide to create a custom frontend for the Hanko FlowAPI login page using the hanko-frontend-sdk.
 ---
 
-# Introductiion
+# Introduction
 
 This guide walks you through building a custom login page for the Hanko FlowAPI using the `hanko-frontend-sdk`. The
 resulting page handles email and passcode login, supports passkey autofill, and includes session management (redirect
@@ -492,6 +492,10 @@ function renderError(error) {
 </Note>
 
 ## Step 4: Run and Test the Login Page
+
+<Warning>
+Always **use your own email address** in the following steps. The Hanko API sends real emails, so proceed with caution!
+</Warning>
 
 <Steps>
 <Step title="Run the Application">

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -455,7 +455,7 @@ function renderPasscodeConfirmation(state) {
     if (state.actions.resend_passcode.enabled) {
       actionsDiv.innerHTML += `<button data-action="resend_passcode">Resend Passcode</button>`;
     }
-    if (state.actions.back ? .enabled) {
+    if (state.actions.back.enabled) {
       actionsDiv.innerHTML += `<button data-action="back">Back</button>`;
     }
 

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -31,7 +31,7 @@ Before starting, ensure you have:
 
 <Steps>
 
-<Step title="Create and Configure a Hanko Cloud Project">
+<Step title="Create a Hanko Cloud Project">
 - Go to [cloud.hanko.io](https://cloud.hanko.io) and log in.
 - In the sidebar, select **All Projects**.
 - Click **Create Project** to open the setup wizard.

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -74,8 +74,7 @@ hanko-login-page/
 ├ script.js
 ├ style.css
 ├ success.html
-├ package.json
-└ .babelrc
+└ package.json
 ```
 </Step>
 
@@ -90,20 +89,8 @@ hanko-login-page/
   },
   "dependencies": {
     "@teamhanko/hanko-frontend-sdk": "^2.0.0",
-    "parcel": "^2.14.0"
-  },
-  "devDependencies": {
-    "@babel/plugin-transform-runtime": "^7.26.0",
-    "@parcel/optimizer-terser": "^2.14.4"
+    "parcel": "^2.14.4"
   }
-}
-```
-</Step>
-
-<Step title="Update '.babelrc'">
-```json
-{
-  "plugins": ["@babel/plugin-transform-runtime"]
 }
 ```
 </Step>
@@ -282,7 +269,7 @@ if (isSuccessPage) {
   });
 
   // Initialize login flow on index.html
-  await hanko.createState("login");
+  hanko.createState("login");
 }
 ```
 <Tip>

--- a/guides/flow-api/build-a-custom-login-page.mdx
+++ b/guides/flow-api/build-a-custom-login-page.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build a Custom Login Page with the FlowAPI
-description: A step-by-step guide to create a custom frontend for the Hanko FlowAPI login page using the hanko-frontend-sdk.
+description: A step-by-step guide to create a custom login page using the Hanko FlowAPI.
 ---
 
 # Introduction
@@ -79,7 +79,7 @@ hanko-login-page/
 ```
 </Step>
 
-<Step title="Create 'package.json'">
+<Step title="Update 'package.json'">
 ```json
 {
   "name": "hanko-login-page",
@@ -100,7 +100,7 @@ hanko-login-page/
 ```
 </Step>
 
-<Step title="Create '.babelrc'">
+<Step title="Update '.babelrc'">
 ```json
 {
   "plugins": ["@babel/plugin-transform-runtime"]
@@ -116,7 +116,7 @@ npm install
 ```
 </Step>
 
-<Step title="Create 'index.html' (the login page)">
+<Step title="Update 'index.html' (the login page)">
 ```html
 <!DOCTYPE html>
 <html lang="en">
@@ -134,7 +134,7 @@ npm install
 ```
 </Step>
 
-<Step title="Create 'success.html' (shown after login)">
+<Step title="Update 'success.html' (shown after login)">
 ```html
 <!DOCTYPE html>
 <html lang="en">
@@ -156,9 +156,9 @@ npm install
 ```
 </Step>
 
-<Step title="Create 'style.css'">
+<Step title="Update 'style.css'">
 
-```css
+```css [expandable]
 body {
   font-family: Arial, sans-serif;
   display: flex;
@@ -241,7 +241,7 @@ Open `http://localhost:3000` in your browser to verify the page loads (it will b
 In `script.js`, initialize the Hanko instance and start the login flow. If the user is on `success.html`, set up logout
 functionality instead.
 
-```js
+```js [expandable]
 import { Hanko } from "@teamhanko/hanko-frontend-sdk";
 
 // Replace with your Hanko Cloud project's API endpoint
@@ -297,7 +297,7 @@ elements with validation attributes (e.g., minlength, maxlength, required) based
 
 Add the following code to the `script.js` file:
 
-```js
+```js [expandable]
 function generateInput(input, options = {}) {
   const { name, type, min_length, max_length, required, error } = input;
   const { autocomplete } = options;
@@ -541,6 +541,17 @@ You've built a working login page that:
 
 <Tip>
 Explore next steps like enhancing the UI with advanced CSS or a framework like Bootstrap, adding support for additional
-states or actions (e.g., password login), or integrating the login page into a larger application.
+states or actions (e.g., password login), or integrating the login page into a larger application. Additionally, the
+FlowAPI supports registration and user profile management flows.
 </Tip>
+
+## References
+
+<Card title="API Reference">
+    [https://docs.hanko.io/api-reference/flow/login](https://docs.hanko.io/api-reference/flow/login)
+</Card>
+<Card title="Frontend SDK">
+    [https://github.com/teamhanko/hanko/tree/main/frontend/frontend-sdk](https://github.com/teamhanko/hanko/tree/main/frontend/frontend-sdk)
+</Card>
+
 

--- a/guides/users/get-user-data.mdx
+++ b/guides/users/get-user-data.mdx
@@ -3,22 +3,12 @@ title: Get User Data
 description: Each project presents unique requirements for user onboarding. In this guide you'll learn to get user data from Hanko.
 ---
 
-<Info>
-**It's good to remember that the user ID is the immmutable identifier**
-
-<Accordion title="But what is an immutable identifier? 🤔">
-    In the context of user data, an "immutable identifier" refers to a piece of information that remains constant and cannot be changed once it's assigned to a user. In this case, the `user id` is the immutable identifier. It's a unique value assigned to each user and it doesn't change even if other user details (like email, username, etc.) are modified.
-</Accordion>
-
-The primary email address can be changed, therefore when handling user registration, the user `id` should be used to
-determine if it's a known user.
-</Info>
-
 ## Getting user data on the Frontend
 
-If you only need the user data for a frontend usage, you can use the `Hanko.user.getCurrent()` function from the
-[hanko-frontend-sdk](https://www.npmjs.com/package/@teamhanko/hanko-frontend-sdk) (it is also re-exported from
-[hanko-elements](https://www.npmjs.com/package/@teamhanko/hanko-elements)):
+To access user data in your frontend application, use the `hanko.getCurrent()` method from the
+[hanko-frontend-sdk](https://www.npmjs.com/package/@teamhanko/hanko-frontend-sdk)
+(also available via [hanko-elements](https://www.npmjs.com/package/@teamhanko/hanko-elements)). To get the user claims
+from the JWT, use the `hanko.validateSession()`function.
 
 <Tabs>
 <Tab title="Nextjs (App directory)">
@@ -30,20 +20,35 @@ import { Hanko } from "@teamhanko/hanko-elements";
 const hankoApi = <YOUR_HANKO_API_URL>;
 const hanko = new Hanko(hankoApi);
 
-const {id, email} = await hanko.user.getCurrent();
-console.log(`user-id: ${id}, email: ${email}`);
+// Fetches the current user's profile information
+const user = await hanko.getUser();
+console.log("User profile:", user);
+// Example output:
+// {
+//   user_id: "123e4567-e89b-12d3-a456-426614174000",
+//   emails: [{ address: "user@example.com", is_primary: true, is_verified: true }],
+//   username: { value: "johndoe" },
+//   created_at: "2025-01-01T10:00:00Z",
+//   updated_at: "2025-04-01T12:00:00Z"
+// }
+
+// Checks the validity of the current session and returns the user claims
+const sessionStatus = await hanko.validateSession();
+console.log("Session status:", sessionStatus);
+// Example output:
+// {
+//   is_valid: true,
+//   claims: {
+//     subject: "123e4567-e89b-12d3-a456-426614174000",
+//     session_id: "789abc",
+//     expiration: "2025-04-25T12:00:00Z",
+//     email: { address: "user@example.com", is_primary: true, is_verified: true },
+//     custom_field: "value"
+//   }
+// }
 ```
 </Tab>
 </Tabs>
-
-
-
-<Info>
-Please keep in mind that if you create a function to get the
-user data, you will be fetching data from the API again every
-time you call the function. We advise you to make sure the function
-is only called once for every user authentication.
-</Info>
 
 ## Getting user data on the Backend
 


### PR DESCRIPTION
- Covers setting up a Hanko Cloud project, creating a local development environment, and implementing a login page with email/passcode authentication, passkey autofill, and session management (login redirect and logout).
- Handles FlowAPI states: error, login_init, login_method_chooser, onboarding_create_passkey, and passcode_confirmation.
- Uses Parcel as a zero-config bundler to resolve npm modules and start a local HTTP server, but I had to create a manual babel config to make the example code work.
- The `@teamhanko/hanko-frontend-sdk` is not released in version 2 yet, so you need to use a local build, like:
```json
  "dependencies": {
    "@teamhanko/hanko-frontend-sdk": "file:/[change-me]/hanko/frontend/frontend-sdk",
    "parcel": "^2.14.0"
  },
```
- If you have troubles compiling the SDK with parcel, there might be a fix needed in the SDK (rename the Error interface under `frontend/frontend-sdk/src/lib/flow-api/types/errror.ts` to `FlowError`).
