### PR TITLE
fix: correct wrong method name

### DIFF
--- a/guides/users/get-user-data.mdx
+++ b/guides/users/get-user-data.mdx
@@ -5,7 +5,7 @@ description: Each project presents unique requirements for user onboarding. In t
 
 ## Getting user data on the Frontend
 
-To access user data in your frontend application, use the `hanko.getCurrent()` method from the
+To access user data in your frontend application, use the `hanko.getUser()` method from the
 [hanko-frontend-sdk](https://www.npmjs.com/package/@teamhanko/hanko-frontend-sdk)
 (also available via [hanko-elements](https://www.npmjs.com/package/@teamhanko/hanko-elements)). To get the user claims
 from the JWT, use the `hanko.validateSession()`function.


### PR DESCRIPTION
This PR updates a reference in the 'Getting user data on the Frontend' section of the docs to reflect the correct method name: `hanko.getCurrent()` 🫱 `hanko.getUser()`.

