### PR TITLE
fix: Update JWT payload docs reference including the broken link

### DIFF
--- a/guides/users/get-user-data.mdx
+++ b/guides/users/get-user-data.mdx
@@ -104,7 +104,9 @@ In addition to the user ID, you can also fetch the current email address, includ
 </Tabs>
 
 <Note>
-  You can refer to [JWT Payload Content](/guides/users/jwt-content) docs for more information on the JWT payload.
+  You can refer to the [User Metadata guide](/guides/users/user-metadata) for details on managing
+  user metadata included in the JWT payload. For information on customizing session tokens with metadata, see the
+  [Session Token Customization guide](/guides/sessions/session-management#session-token-customization).
 </Note>
 
 ### Get user data using the Hanko Admin API


### PR DESCRIPTION
Replace outdated reference to "JWT Payload Content" with links to the "User Metadata" guide and "Session Token Customization" guide in the [documentation](https://docs.hanko.io/guides/users/get-user-data#getting-email-from-the-jwt).

<img width="734" height="103" alt="image" src="https://github.com/user-attachments/assets/611763a3-7982-46b5-9cfa-5109074157d3" />

👇

<img width="739" height="110" alt="image" src="https://github.com/user-attachments/assets/172fb2b4-3a1f-4551-9940-156943dc6010" />
