### PR TITLE
[openapi-specification] rename `public-key` to `public_key`

### DIFF
--- a/openapi-flow.yaml
+++ b/openapi-flow.yaml
@@ -1213,7 +1213,7 @@ components:
           properties:
             name:
               enum:
-                - "public-key"
+                - "public_key"
             type:
               enum:
                 - "json"
@@ -2661,11 +2661,11 @@ components:
                   type:
                     type: string
                     enum:
-                      - public-key
+                      - public_key
                   alg:
                     type: number
               example:
-                - type: public-key
+                - type: public_key
                   alg: -7
             timeout:
               type: number
@@ -2733,8 +2733,8 @@ components:
                   type:
                     type: string
                     enum:
-                      - public-key
-                    example: public-key
+                      - public_key
+                    example: public_key
                   id:
                     type: string
                     format: base64url
@@ -2881,7 +2881,7 @@ components:
         last_used_at:
           type: string
           format: date-time
-        public-key:
+        public_key:
           type: string
         transports:
           type: array

--- a/openapi-passkeys.yaml
+++ b/openapi-passkeys.yaml
@@ -842,7 +842,7 @@ components:
           type: string
         type:
           enum:
-            - public-key
+            - public_key
       required:
         - id
         - type
@@ -920,7 +920,7 @@ components:
       properties:
         type:
           enum:
-            - public-key
+            - public_key
         alg:
           type: integer
           format: int32
@@ -933,7 +933,7 @@ components:
       properties:
         type:
           enum:
-            - public-key
+            - public_key
         id:
           type: string
         transports:

--- a/openapi-public.yaml
+++ b/openapi-public.yaml
@@ -325,7 +325,7 @@ paths:
                       timeout: 60000
                       rpId: localhost
                       allowCredentials:
-                        - type: public-key
+                        - type: public_key
                           id: Mepptysj5ZZrTlg0qiLbsZ068OtQMeGVAikVy2n1hvvG...
                       userVerification: required
                 disco:
@@ -1414,11 +1414,11 @@ components:
                   type:
                     type: string
                     enum:
-                      - public-key
+                      - public_key
                   alg:
                     type: number
               example:
-                - type: public-key
+                - type: public_key
                   alg: -7
             timeout:
               type: number
@@ -1486,8 +1486,8 @@ components:
                   type:
                     type: string
                     enum:
-                      - public-key
-                    example: public-key
+                      - public_key
+                    example: public_key
                   id:
                     type: string
                     format: base64url
@@ -1594,8 +1594,8 @@ components:
         type:
           type: string
           enum:
-            - public-key
-          example: public-key
+            - public_key
+          example: public_key
         response:
           type: object
           properties:
@@ -1628,8 +1628,8 @@ components:
         type:
           type: string
           enum:
-            - public-key
-          example: public-key
+            - public_key
+          example: public_key
         response:
           type: object
           properties:


### PR DESCRIPTION
- Renamed all occurrences and examples in the OpenAPI specification YAMLs where the enum value was said to be `public-key` to snake-case `public_key`

closes #158 