### PR TITLE
[openapi-flow specification] set type of InputPassword to be `password`

### DIFF
--- a/openapi-flow.yaml
+++ b/openapi-flow.yaml
@@ -1120,7 +1120,7 @@ components:
                 - "password"
             type:
               enum:
-                - "string"
+                - "password"
             min_length:
               default: 8
             required:


### PR DESCRIPTION
- Changed enum of `type` property on `InputPassword` to only have `password` as allowed value instead of `string`

This change lines up with the actual API response and does not introduce anything new, it only aligns the documentation with the servers behaviour.

closes #159 