### PR TITLE
fix: remove second guide entry from menu

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -50,8 +50,7 @@
                       "quickstarts/backend/javascript",
                       "quickstarts/backend/java_spring",
                       "quickstarts/backend/python",
-                      "quickstarts/backend/rust",
-                      "quickstarts/backend/java_spring"
+                      "quickstarts/backend/rust"
                     ]
                   }
                 ]


### PR DESCRIPTION
# Description

Remove the second entry of the "Java (Spring)" guide from the menu.