### PR TITLE
Revise migration guide for Hanko 3.0.0 release

### DIFF
--- a/guides/migrations/2.x.x-to-3.x.x.mdx
+++ b/guides/migrations/2.x.x-to-3.x.x.mdx
@@ -9,7 +9,7 @@ description: Migration guide for upgrading from Hanko 2.x.x to 3.0.0
 Hanko 3.0.0 removes previously deprecated API endpoints. This guide outlines the breaking changes and migration path for upgrading from version 2.x.x to 3.0.0.
 
 <Warning>
-  Hanko 3.0.0 is scheduled for release on Hanko Cloud on **May 20, 2026**. Please plan your migration accordingly.
+  Hanko 3.0.0 is scheduled for release on Hanko Cloud on **May 26, 2026**. Please plan your migration accordingly.
 </Warning>
 
 
@@ -57,7 +57,7 @@ The following Public API endpoints have been deprecated and will be removed in v
 ## Migration Path
 
 <Note>
-    Exception: If your integration only uses, `hanko-elements` version **1.0.0 or later**, and not using the Hanko API directly, no migration changes are required.
+    Exception: If your integration only uses `hanko-elements` version **1.0.0 or later** and does not use the Hanko API directly, no migration changes are required.
 </Note>
 
 All deprecated endpoints have been replaced with the new **Flow API**, which provides a unified and streamlined authentication interface.
@@ -68,11 +68,11 @@ Check out the [Understanding the Flow API guide](/using-the-api/understanding-th
 
 To ensure a smooth transition:
 
-1. Review your current implementation and identify usage of deprecated endpoints
-2. Migrate to the Flow API before the May 20, 2026 release date
-3. Test your integration thoroughly in a development environment
-4. Refer to the [Flow API documentation](/api-reference/flow) for implementation details
+1. Review your current implementation and check for any usage of deprecated API endpoints or `hanko-elements` versions older than 1.0.0.
+2. When using any of the deprecated endpoints, migrate to the Flow API before the May 26, 2026 release date. Refer to the [Flow API documentation](/api-reference/flow) for implementation details.
+3. When using `hanko-elements` versions older than 1.0.0, migrate to the latest version before the May 26, 2026 release date.
+4. Test your integration thoroughly in a development environment.
 
 <Note>
-  Need assistance with your migration? Contact our support team or visit our [community forum](/community-support) for help.
+  Need assistance with your migration? Contact our [support team](https://www.hanko.io/support) or visit our [community Discord](/community-support) for help.
 </Note>


### PR DESCRIPTION
Updated release date and migration instructions for Hanko 3.0.0.