### PR TITLE
Replace deprecated getUser() with getCurrentUser() in guides

### DIFF
--- a/guides/hanko-elements/using-frontend-sdk.mdx
+++ b/guides/hanko-elements/using-frontend-sdk.mdx
@@ -110,7 +110,7 @@ console.log("Session token:", token);
 Get the user data:
 
 ```js
-const user = await hanko.getUser();
+const user = await hanko.getCurrentUser();
 console.log("User profile:", user.user_id, user.emails);
 ```
 

--- a/guides/user-data/frontend.mdx
+++ b/guides/user-data/frontend.mdx
@@ -31,7 +31,7 @@ import HankoAbout from '/snippets/hanko-about.mdx'
 
 ## Get user data from API
 
-To access user data in your frontend application, use the `hanko.getUser()` method from the [hanko-frontend-sdk](https://www.npmjs.com/package/@teamhanko/hanko-frontend-sdk)
+To access user data in your frontend application, use the `hanko.getCurrentUser()` method from the [hanko-frontend-sdk](https://www.npmjs.com/package/@teamhanko/hanko-frontend-sdk)
 (also available via [hanko-elements](https://www.npmjs.com/package/@teamhanko/hanko-elements)).
 
 ```js
@@ -41,7 +41,7 @@ const hankoApi = "<YOUR_HANKO_API_URL>";
 const hanko = new Hanko(hankoApi);
 
 // Fetches the current user's profile information
-const user = await hanko.getUser();
+const user = await hanko.getCurrentUser();
 console.log("User profile:", user);
 // Example output:
 // {

--- a/quickstarts/frontend/angular.mdx
+++ b/quickstarts/frontend/angular.mdx
@@ -475,7 +475,7 @@ To verify that it works, logout on your app and go to /dashboard, you should get
 ## Getting user data
 
 Let's use the Hanko SDK to get user data to display on our dashboard page.
-For the user information we will use [hanko.GetUser()](https://teamhanko.github.io/hanko/jsdoc/hanko-frontend-sdk/index.html#getting-the-user-object)
+For the user information we will use [hanko.getCurrentUser()](https://teamhanko.github.io/hanko/jsdoc/hanko-frontend-sdk/index.html#getting-the-user-object)
 
 Lets update our dashboard page.
 

--- a/quickstarts/frontend/angular.mdx
+++ b/quickstarts/frontend/angular.mdx
@@ -518,7 +518,7 @@ Lets update our dashboard page.
     ngOnInit(): void {
       const hanko = new Hanko(this.hankoApi);
       //Get user to get the user information
-      hanko.getUser().then((user: any) => {
+      hanko.getCurrentUser().then((user: any) => {
         this.email = user.emails?.[0]?.address || 'Unknown';
         this.id = user.user_id || 'Unknown';
       }).catch(err => console.error('Failed to fetch user', err));

--- a/quickstarts/frontend/react.mdx
+++ b/quickstarts/frontend/react.mdx
@@ -391,7 +391,7 @@ export default function Dashboard() {
 
   useEffect(() => setHanko(new Hanko(hankoApi)), []);
     useEffect(() => {
-      hanko?.getUser()
+      hanko?.getCurrentUser()
         .then((user) => {
           console.log("User profile:", user);// Log user Profile
           console.log(user.emails?.[0]?.address);

--- a/quickstarts/frontend/svelte.mdx
+++ b/quickstarts/frontend/svelte.mdx
@@ -301,8 +301,8 @@ Lets update the `dashboard` page to log some of the information from the User An
 
     async function fetchUserData() {
       const hanko = new Hanko(hankoApi);
-      const _email = (await hanko.getUser()).emails?.[0]?.address;
-      const _id = (await hanko.getUser()).user_id;
+      const _email = (await hanko.getCurrentUser()).emails?.[0]?.address;
+      const _id = (await hanko.getCurrentUser()).user_id;
       return { email: _email, id: _id };
     }
 

--- a/quickstarts/frontend/svelte.mdx
+++ b/quickstarts/frontend/svelte.mdx
@@ -285,7 +285,7 @@ To use the Protected route wrap your `Dashboard` in the Protected Route;
 ## Getting user and session data
 
 Lets use the Hanko SDK to Get User Data to display on the dashboard.
-For the User Information we will use [hanko.GetUser()](https://teamhanko.github.io/hanko/jsdoc/hanko-frontend-sdk/index.html#getting-the-user-object)
+For the User Information we will use [hanko.getCurrentUser()](https://teamhanko.github.io/hanko/jsdoc/hanko-frontend-sdk/index.html#getting-the-user-object)
 
 Lets update the `dashboard` page to log some of the information from the User And Session.
 

--- a/quickstarts/fullstack/next.mdx
+++ b/quickstarts/fullstack/next.mdx
@@ -498,7 +498,7 @@ export default function Dashboard() {
 
     useEffect(() => setHanko(new Hanko(hankoApi)), []);
       useEffect(() => {
-        hanko?.getUser()
+        hanko?.getCurrentUser()
           .then((user) => {
             console.log("User profile:", user);// Log user Profile
             console.log(user.emails?.[0]?.address);
@@ -533,7 +533,7 @@ export default function Dashboard() {
 
     useEffect(() => setHanko(new Hanko(hankoApi)), []);
       useEffect(() => {
-        hanko?.getUser()
+        hanko?.getCurrentUser()
           .then((user) => {
             console.log("User profile:", user);// Log user Profile
             console.log(user.emails?.[0]?.address);

--- a/quickstarts/fullstack/next.mdx
+++ b/quickstarts/fullstack/next.mdx
@@ -523,7 +523,7 @@ Pages Router dashboard with client-side user data retrieval.
 import HankoProfile from "@/components/HankoProfile";
 import LogoutButton from "@/components/LogoutButton";
 
-iimport { Hanko } from "@teamhanko/hanko-elements";
+import { Hanko } from "@teamhanko/hanko-elements";
 import { useState, useEffect } from "react";
 
 const hankoApi = process.env.NEXT_PUBLIC_HANKO_API_URL || "";
@@ -598,7 +598,6 @@ export async function getUserData() {
       console.log(error)
       return null;
     }
-    return
 }
 ```
 

--- a/quickstarts/fullstack/sveltekit.mdx
+++ b/quickstarts/fullstack/sveltekit.mdx
@@ -322,8 +322,8 @@ Enhanced dashboard page that retrieves and displays user data (email and ID) usi
 
     async function fetchUserData() {
       const hanko = new Hanko(hankoApi);
-      const _email = (await hanko.getUser()).emails?.[0]?.address;
-      const _id = (await hanko.getUser()).user_id;
+      const _email = (await hanko.getCurrentUser()).emails?.[0]?.address;
+      const _id = (await hanko.getCurrentUser()).user_id;
       return { email: _email, id: _id };
     }
   

--- a/resources/prompts/javascript.mdx
+++ b/resources/prompts/javascript.mdx
@@ -140,7 +140,7 @@ Use only the **current** approach from Hanko's documentation:
 
     // Get current user data
     try {
-        const user = await hanko.getUser();
+        const user = await hanko.getCurrentUser();
         console.log("User ID:", user.user_id);
         console.log("Email:", user.emails?.[0]?.address);
         

--- a/resources/prompts/sveltekit.mdx
+++ b/resources/prompts/sveltekit.mdx
@@ -195,7 +195,7 @@ const authenticatedUser = async (event: RequestEvent) => {
 
   async function fetchUserData() {
     const hanko = new Hanko(hankoApi);
-    const user = await hanko.getUser();
+    const user = await hanko.getCurrentUser();
     email = user.emails?.[0]?.address || '';
     userId = user.user_id || '';
   }


### PR DESCRIPTION
## Summary
- Hanko v3 removed the frontend SDK function `getUser()` in favor of `getCurrentUser()` (see the 2.x.x to 3.x.x migration guide).
- Updated all quickstarts and guides that still called `hanko.getUser()` to use `hanko.getCurrentUser()` instead, across React, Angular, Svelte, SvelteKit, and Next.js quickstarts, the user-data guides, the hanko-elements frontend-sdk guide, and the JS/SvelteKit prompt resources.
- Left the migration guide itself unchanged since it correctly documents the deprecation.
- Left unrelated getUserData/getUserId/admin API getUser operationId occurrences untouched -- these are distinct, unrelated identifiers, not the deprecated SDK method.

## Test plan
- [x] Searched the repo for all getUser occurrences and manually verified each one before editing.
- [x] Confirmed no remaining hanko.getUser() SDK calls outside the migration guide.